### PR TITLE
Fix pagination issue

### DIFF
--- a/client/src/components/Images.js
+++ b/client/src/components/Images.js
@@ -11,10 +11,7 @@ export class Images extends Component {
   };
 
   componentDidMount() {
-    const { count, start } = this.state;
-    axios
-      .get(`/api/photos?count=${count}&start=${start}`)
-      .then(res => this.setState({ images: res.data }));
+    this.fetchImages();
   }
 
   fetchImages = () => {


### PR DESCRIPTION
After the component is mounted start state is not updated. So when more call is done, first call will fetch first set of data again.