### PR TITLE
Add React dependencies install command from server package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Part of a challenge from https://scotch.io/bar-talk/code-challenge-16-infinite-s
 ```bash
 # Install Node dependencies
 npm install
+
 # Install React dependencies
+npm run client-install
 
 # Go into config/server and add your own API keys for Unsplash
 

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "client-install": "npm install --prefix client",
     "start": "node server",
     "server": "nodemon server",
     "client": "npm start --prefix client",


### PR DESCRIPTION
Most of the time developers(including myself) forget to run npm install command inside client folder so just added user friendly command in main package.json